### PR TITLE
Update README.md to highlight it must be a child plugin of `gatsby-transformer-remark`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Open a terminal at the root of your project and type:
 gatsby-remark-strava-token
 ```
 
-3. Add the plugin in your `gatsby-config.js` file
+3. Add the plugin in your `gatsby-config.js` file. It's important that it is a child plugin of `gatsby-transformer-remark` as below, otherwise it won't work. 
 
 ```js
 require("dotenv").config()


### PR DESCRIPTION
Hey mate! Love the plugin, thanks for making it. I lost 5-10 minutes until I realised that the plugin had to be a child/sub-plugin of `gatsby-transformer-remark`, so maybe a little comment here will save someone else that time! Cheers. 